### PR TITLE
Implement OTP-based multi-stage voting

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,41 @@
 from flask import Flask, render_template, request, jsonify
-import json, os
+import json, os, random, datetime
 
 app = Flask(__name__)
+
+VOTERS_FILE = 'voters.json'
+VOTES_FILE = 'votes.json'
+CONTACTS_FILE = 'contacts.json'
+
+# In-memory store for active OTPs
+# Structure: {'VIN001': {'otp': '123456', 'timestamp': datetime_object, 'phone_last4': '0001'}}
+active_otps = {}
+OTP_EXPIRY_MINUTES = 5
+
+def load_json_file(file_path, default_value=None):
+    if default_value is None:
+        default_value = [] # Default to empty list if not specified
+    if os.path.exists(file_path):
+        with open(file_path, 'r') as f:
+            try:
+                return json.load(f)
+            except json.JSONDecodeError:
+                app.logger.error(f"Error decoding JSON from {file_path}")
+                return default_value
+    return default_value
+
+def save_json_file(file_path, data):
+    with open(file_path, 'w') as f:
+        json.dump(data, f, indent=2)
+
+def load_voters():
+    return load_json_file(VOTERS_FILE, [])
+
+def load_votes():
+    return load_json_file(VOTES_FILE, [])
+
+def save_votes(votes):
+    save_json_file(VOTES_FILE, votes)
 
 @app.route('/')
 def home():
@@ -10,36 +44,64 @@ def home():
 @app.route('/submit_contact', methods=['POST'])
 def contact():
     data = request.get_json()
-    if not all(k in data for k in ("name", "email", "message")):
+    if not data or not all(k in data for k in ("name", "email", "message")): # Ensure data is not None
         return jsonify({"status": "error", "message": "Missing required fields."}), 400
 
-    file_path = 'contacts.json'
-    if os.path.exists(file_path):
-        with open(file_path, 'r') as f:
-            existing = json.load(f)
-    else:
-        existing = []
-
-    existing.append(data)
-    with open(file_path, 'w') as f:
-        json.dump(existing, f, indent=2)
+    existing_contacts = load_json_file(CONTACTS_FILE, [])
+    existing_contacts.append(data)
+    save_json_file(CONTACTS_FILE, existing_contacts)
 
     return jsonify({"status": "success", "message": "Submission received."})
 
-VOTES_FILE = 'votes.json'
+@app.route('/request_otp', methods=['POST'])
+def request_otp():
+    data = request.get_json()
+    if not data or 'vin' not in data:
+        return jsonify({"status": "error", "message": "VIN is required."}), 400
 
-def load_votes():
-    if os.path.exists(VOTES_FILE):
-        with open(VOTES_FILE, 'r') as f:
-            try:
-                return json.load(f)
-            except json.JSONDecodeError:
-                return []
-    return []
+    vin_to_check = data['vin']
+    phone_to_check = data.get('phone') # Optional phone number from form
 
-def save_votes(votes):
-    with open(VOTES_FILE, 'w') as f:
-        json.dump(votes, f, indent=2)
+    voters = load_voters()
+    voter_info = None
+    for v in voters:
+        if v.get('vin') == vin_to_check:
+            # If phone is provided in request, it must match the registered phone
+            if phone_to_check and v.get('phone') != phone_to_check:
+                return jsonify({"status": "error", "message": "VIN and Phone number do not match registered records."}), 400
+            voter_info = v
+            break
+
+    if not voter_info:
+        return jsonify({"status": "error", "message": "VIN not found or does not match registered phone."}), 404
+
+    # Clean up expired OTPs first
+    now = datetime.datetime.utcnow()
+    expired_vins = [
+        vin for vin, otp_data in list(active_otps.items()) # list() to avoid runtime dict modification error
+        if now > otp_data['timestamp'] + datetime.timedelta(minutes=OTP_EXPIRY_MINUTES)
+    ]
+    for vin in expired_vins:
+        del active_otps[vin]
+        app.logger.info(f"Expired OTP for VIN {vin} removed.")
+
+    # For this demo, allow generating a new OTP even if one exists and is not expired.
+    # In a real scenario, you might prevent rapid re-requests.
+
+    otp_code = str(random.randint(100000, 999999))
+    active_otps[vin_to_check] = {
+        'otp': otp_code,
+        'timestamp': now,
+        'phone_last4': voter_info.get('phone', 'XXXX')[-4:]
+    }
+    app.logger.info(f"Generated OTP {otp_code} for VIN {vin_to_check}")
+
+    return jsonify({
+        "status": "success",
+        "message": f"OTP (simulated) generated for VIN {vin_to_check}. For testing, OTP is {otp_code}. It would be sent to ...{active_otps[vin_to_check]['phone_last4']}.",
+        "otp_for_testing": otp_code, # Clearly mark for testing
+        "phone_last4": active_otps[vin_to_check]['phone_last4']
+    })
 
 @app.route('/submit_vote', methods=['POST'])
 def submit_vote():
@@ -48,31 +110,46 @@ def submit_vote():
         return jsonify({"status": "error", "message": "Missing required fields (vin, otp, candidate)."}), 400
 
     vin = data['vin']
-    otp = data['otp']
+    otp_received = data['otp']
     candidate = data['candidate']
 
-    # Basic validation (can be expanded)
-    if not vin or not otp or not candidate:
-        return jsonify({"status": "error", "message": "All fields must be filled."}), 400
+    if not vin or not otp_received or not candidate or candidate == "Select a candidate":
+        return jsonify({"status": "error", "message": "All fields must be filled and a candidate selected."}), 400
 
-    # In a real application, OTP would be validated against a generated & stored OTP
-    # and VIN would be checked against a voter registration database.
-    import datetime
+    # Validate OTP
+    now = datetime.datetime.utcnow()
+    otp_data = active_otps.get(vin)
 
+    if not otp_data:
+        return jsonify({"status": "error", "message": "No OTP request found for this VIN or OTP was not generated. Please request an OTP first."}), 400
+
+    if now > otp_data['timestamp'] + datetime.timedelta(minutes=OTP_EXPIRY_MINUTES):
+        del active_otps[vin] # Clean up expired OTP
+        app.logger.info(f"Attempt to use expired OTP for VIN {vin}.")
+        return jsonify({"status": "error", "message": "OTP has expired. Please request a new one."}), 400
+
+    if otp_data['otp'] != otp_received:
+        return jsonify({"status": "error", "message": "Invalid OTP."}), 400
+
+    # OTP is valid, proceed with voting logic
     votes = load_votes()
 
     # Check if VIN has already voted
-    for vote in votes:
-        if vote.get('vin') == vin:
+    for vote_record in votes: # Renamed 'vote' to 'vote_record' to avoid conflict
+        if vote_record.get('vin') == vin:
             return jsonify({"status": "error", "message": f"VIN {vin} has already voted."}), 409 # 409 Conflict
 
     new_vote = {
         "vin": vin,
         "candidate": candidate,
-        "timestamp": datetime.datetime.utcnow().isoformat()
+        "timestamp": now.isoformat() # Use current time for vote timestamp
     }
     votes.append(new_vote)
     save_votes(votes)
+
+    # Invalidate OTP after successful use
+    del active_otps[vin]
+    app.logger.info(f"OTP for VIN {vin} used successfully and invalidated.")
 
     return jsonify({"status": "success", "message": "Vote submitted successfully."})
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -97,21 +97,35 @@
   <section id="voteDemo" class="py-5">
     <div class="container">
       <h2 class="text-center mb-4">Simulate a Demo Vote</h2>
-      <div class="mb-3">
-        <input type="text" id="vin" class="form-control" placeholder="Enter Mock Voter ID (VIN)">
+
+      <!-- Stage 1: VIN and Phone Input -->
+      <div id="stage1VinPhoneInput">
+        <div class="mb-3">
+          <input type="text" id="vin" class="form-control" placeholder="Enter Mock Voter ID (VIN)" autocomplete="off">
+        </div>
+        <div class="mb-3">
+          <input type="text" id="phone" class="form-control" placeholder="Enter Registered Phone (Optional, for verification)" autocomplete="off">
+        </div>
+        <button onclick="requestOtp()" class="btn btn-primary">Request OTP</button>
       </div>
-      <div class="mb-3">
-        <input type="text" id="otp" class="form-control" placeholder="Enter OTP">
+
+      <!-- Stage 2: OTP Input and Voting -->
+      <div id="stage2OtpVote" class="d-none">
+        <p id="otpSentMessage" class="text-info"></p>
+        <div class="mb-3">
+          <input type="text" id="otp" class="form-control" placeholder="Enter OTP Received" autocomplete="off">
+        </div>
+        <div class="mb-3">
+          <select id="candidate" class="form-select">
+            <option selected disabled>Select a candidate</option>
+            <option value="Candidate A">Candidate A</option>
+            <option value="Candidate B">Candidate B</option>
+            <option value="Candidate C">Candidate C</option>
+          </select>
+        </div>
+        <button onclick="simulateVote()" class="btn btn-success">Cast Vote</button>
       </div>
-      <div class="mb-3">
-        <select id="candidate" class="form-select">
-          <option selected disabled>Select a candidate</option>
-          <option value="Candidate A">Candidate A</option>
-          <option value="Candidate B">Candidate B</option>
-          <option value="Candidate C">Candidate C</option>
-        </select>
-      </div>
-      <button onclick="simulateVote()" class="btn btn-success">Cast Vote</button>
+
       <div id="vote-spinner" class="spinner-border text-primary d-none mt-3" role="status"></div>
       <div id="vote-status" class="mt-3"></div>
     </div>
@@ -240,6 +254,7 @@
     }
 
     let resultsChart; // Declare chart variable in a broader scope
+    let currentVinForVoting = ""; // Store VIN after OTP request
 
     async function fetchResults() {
       try {
@@ -258,27 +273,17 @@
 
     function updateChart(newResults) {
       if (!resultsChart || !newResults) return;
-
-      const candidateNames = Object.keys(newResults);
-      const voteCounts = Object.values(newResults);
-
-      // Ensure all candidates are present in labels, even if count is 0 for some initially
       const allCandidates = ['Candidate A', 'Candidate B', 'Candidate C'];
-      const currentLabels = resultsChart.data.labels;
-      allCandidates.forEach(c => {
-          if(!currentLabels.includes(c)) currentLabels.push(c);
-      });
+      let labelsToUse = [...new Set([...allCandidates, ...Object.keys(newResults)])]; // Merge and unique
 
-      const dataForChart = currentLabels.map(label => newResults[label] || 0);
-
-      resultsChart.data.labels = currentLabels;
-      resultsChart.data.datasets[0].data = dataForChart;
+      resultsChart.data.labels = labelsToUse;
+      resultsChart.data.datasets[0].data = labelsToUse.map(label => newResults[label] || 0);
       resultsChart.update();
     }
 
     async function initializeChart() {
       const initialResults = await fetchResults() || { 'Candidate A': 0, 'Candidate B': 0, 'Candidate C': 0 };
-      const candidateLabels = ['Candidate A', 'Candidate B', 'Candidate C']; // Default labels
+      const candidateLabels = ['Candidate A', 'Candidate B', 'Candidate C'];
       const initialData = candidateLabels.map(label => initialResults[label] || 0);
 
       resultsChart = new Chart(document.getElementById('resultsChart'), {
@@ -288,26 +293,75 @@
           datasets: [{
             label: 'Votes',
             data: initialData,
-            backgroundColor: ['#007bff', '#28a745', '#ffc107', '#dc3545', '#6c757d'] // Added more colors if needed
+            backgroundColor: ['#007bff', '#28a745', '#ffc107', '#dc3545', '#6c757d']
           }]
         },
-        options: {
-          responsive: true
-        }
+        options: { responsive: true }
       });
-      updateChart(initialResults); // Ensure chart reflects fetched or default data
+      updateChart(initialResults);
     }
 
-    // Modify simulateVote to call fetchResults and updateChart
-    async function simulateVote() {
+    async function requestOtp() {
       const vin = document.getElementById('vin').value;
+      const phone = document.getElementById('phone').value; // Optional
+      const spinner = document.getElementById("vote-spinner");
+      const statusDiv = document.getElementById("vote-status");
+      const otpSentMessageDiv = document.getElementById("otpSentMessage");
+
+      if (!vin) {
+        statusDiv.innerHTML = '<span class="text-danger">Please enter your Voter ID (VIN).</span>';
+        return;
+      }
+
+      spinner.classList.remove("d-none");
+      statusDiv.innerHTML = "Requesting OTP...";
+      otpSentMessageDiv.innerHTML = "";
+
+
+      try {
+        const payload = { vin };
+        if (phone) { // Add phone to payload only if it's provided
+            payload.phone = phone;
+        }
+        const response = await fetch('/request_otp', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        const result = await response.json();
+
+        if (response.ok && result.status === "success") {
+          currentVinForVoting = vin; // Store VIN for the actual vote submission
+          document.getElementById('stage1VinPhoneInput').classList.add('d-none');
+          document.getElementById('stage2OtpVote').classList.remove('d-none');
+          otpSentMessageDiv.innerHTML = `OTP sent to registered phone ending in ...${result.phone_last4}. Please enter it below. (Test OTP: ${result.otp_for_testing})`; // Display for testing
+          statusDiv.innerHTML = ""; // Clear previous status
+          // Optionally disable VIN input here or clear it if needed
+          document.getElementById('vin').readOnly = true;
+          document.getElementById('phone').readOnly = true;
+        } else {
+          statusDiv.innerHTML = `<span class="text-danger">${result.message || 'Error requesting OTP.'}</span>`;
+        }
+      } catch (error) {
+        statusDiv.innerHTML = `<span class="text-danger">Network error or server unavailable while requesting OTP.</span>`;
+        console.error("Error requesting OTP:", error);
+      } finally {
+        spinner.classList.add("d-none");
+      }
+    }
+
+    async function simulateVote() {
       const otp = document.getElementById('otp').value;
       const candidate = document.getElementById('candidate').value;
       const spinner = document.getElementById("vote-spinner");
       const statusDiv = document.getElementById("vote-status");
 
-      if (!vin || !otp || candidate === "Select a candidate") {
-        statusDiv.innerHTML = '<span class="text-danger">Please fill in all fields and select a candidate.</span>';
+      if (!currentVinForVoting) { // Should not happen if UI flow is correct
+          statusDiv.innerHTML = '<span class="text-danger">Error: VIN not set. Please request OTP first.</span>';
+          return;
+      }
+      if (!otp || candidate === "Select a candidate") {
+        statusDiv.innerHTML = '<span class="text-danger">Please enter OTP and select a candidate.</span>';
         return;
       }
 
@@ -318,14 +372,27 @@
         const response = await fetch('/submit_vote', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ vin, otp, candidate })
+          body: JSON.stringify({ vin: currentVinForVoting, otp, candidate })
         });
         const result = await response.json();
 
         if (response.ok && result.status === "success") {
           statusDiv.innerHTML = `<span class="text-success">${result.message}</span>`;
-          const latestResults = await fetchResults(); // Fetch results after successful vote
+          const latestResults = await fetchResults();
           if (latestResults) updateChart(latestResults);
+          // Reset form for next vote simulation after a delay or on a button click
+          setTimeout(() => {
+            document.getElementById('stage2OtpVote').classList.add('d-none');
+            document.getElementById('stage1VinPhoneInput').classList.remove('d-none');
+            document.getElementById('otp').value = '';
+            document.getElementById('candidate').selectedIndex = 0;
+            document.getElementById('vin').readOnly = false;
+            document.getElementById('vin').value = '';
+            document.getElementById('phone').readOnly = false;
+            document.getElementById('phone').value = '';
+            statusDiv.innerHTML = "";
+            currentVinForVoting = "";
+          }, 3000); // Reset after 3 seconds
         } else {
           statusDiv.innerHTML = `<span class="text-danger">${result.message || 'Error submitting vote.'}</span>`;
         }
@@ -337,9 +404,11 @@
       }
     }
 
-
     document.addEventListener('DOMContentLoaded', () => {
       initializeChart();
+      // Ensure correct initial state
+      document.getElementById('stage1VinPhoneInput').classList.remove('d-none');
+      document.getElementById('stage2OtpVote').classList.add('d-none');
     });
 
     document.getElementById('contactForm').addEventListener('submit', async function (e) {

--- a/voters.json
+++ b/voters.json
@@ -1,0 +1,27 @@
+[
+  {
+    "vin": "VIN001",
+    "phone": "+2348000000001",
+    "name": "Adewale Adebayo"
+  },
+  {
+    "vin": "VIN002",
+    "phone": "+2348000000002",
+    "name": "Aisha Ibrahim"
+  },
+  {
+    "vin": "VIN003",
+    "phone": "+2348000000003",
+    "name": "Chinedu Okoro"
+  },
+  {
+    "vin": "VIN004",
+    "phone": "+2348000000004",
+    "name": "Fatima Bello"
+  },
+  {
+    "vin": "VIN005",
+    "phone": "+2348000000005",
+    "name": "Emeka Nwosu"
+  }
+]


### PR DESCRIPTION
This commit introduces a two-stage voting process:
1. User requests an OTP by providing their VIN (and optionally phone).
2. User submits the OTP along with their candidate choice to vote.

Backend changes (`app.py`):
- Added `voters.json` to store mock voter data.
- Implemented `/request_otp` endpoint:
  - Validates VIN against `voters.json`.
  - Generates a 6-digit OTP.
  - Stores OTP in-memory (`active_otps`) with a 5-minute expiry.
  - Returns OTP to client for testing/simulation purposes.
- Modified `/submit_vote` endpoint:
  - Now requires VIN, OTP, and candidate.
  - Validates OTP against `active_otps` (checks existence, correctness, expiry).
  - Invalidates OTP after use.
  - Retains "one VIN, one vote" logic.
- Added helper functions for JSON loading/saving.

Frontend changes (`templates/index.html`):
- Updated HTML to create two distinct stages for VIN/Phone input and OTP/Vote input.
- Added JavaScript function `requestOtp()`:
  - Calls `/request_otp`.
  - Manages UI transition from stage 1 to stage 2.
  - Displays (for testing) the OTP received.
- Modified `simulateVote()`:
  - Collects VIN (stored after OTP request), OTP, and candidate.
  - Calls updated `/submit_vote`.
  - Resets UI to stage 1 after a successful vote to allow further simulations.
- Chart logic remains largely the same, updated to reflect new data flow.